### PR TITLE
remove rule Magento2.Commenting.ClassPropertyPHPDocFormatting.Missing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "magento/magento-coding-standard": "v25"
+        "magento/magento-coding-standard": "v27"
 
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,26 +4,26 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b2e05af333dd3642dcff48c0785603e7",
+    "content-hash": "01c92bf549ee394bc0454e1d39506c7f",
     "packages": [
         {
             "name": "magento/magento-coding-standard",
-            "version": "25",
+            "version": "27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/magento/magento-coding-standard.git",
-                "reference": "7be8305949f6683ff08534fbc22e5d42a1c4eba7"
+                "reference": "097bda3e015f35dc7c2efc0b8c7a7d8dfc158a63"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/magento/magento-coding-standard/zipball/7be8305949f6683ff08534fbc22e5d42a1c4eba7",
-                "reference": "7be8305949f6683ff08534fbc22e5d42a1c4eba7",
+                "url": "https://api.github.com/repos/magento/magento-coding-standard/zipball/097bda3e015f35dc7c2efc0b8c7a7d8dfc158a63",
+                "reference": "097bda3e015f35dc7c2efc0b8c7a7d8dfc158a63",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-simplexml": "*",
-                "php": ">=7.3",
+                "php": "^8.1||^8.2",
                 "phpcompatibility/php-compatibility": "^9.3",
                 "rector/rector": "^0.13.0",
                 "squizlabs/php_codesniffer": "^3.6.1",
@@ -50,9 +50,9 @@
             "description": "A set of Magento specific PHP CodeSniffer rules.",
             "support": {
                 "issues": "https://github.com/magento/magento-coding-standard/issues",
-                "source": "https://github.com/magento/magento-coding-standard/tree/v25"
+                "source": "https://github.com/magento/magento-coding-standard/tree/v27"
             },
-            "time": "2022-06-21T10:23:58+00:00"
+            "time": "2022-10-17T15:19:28+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
@@ -118,16 +118,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.8.x-dev",
+            "version": "1.9.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "00fa5a52dfb94da1c2f71fe26e988f45ff276f8d"
+                "reference": "c1ea106f9a101643d4e224c0917cef4eb0c1f60c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/00fa5a52dfb94da1c2f71fe26e988f45ff276f8d",
-                "reference": "00fa5a52dfb94da1c2f71fe26e988f45ff276f8d",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/c1ea106f9a101643d4e224c0917cef4eb0c1f60c",
+                "reference": "c1ea106f9a101643d4e224c0917cef4eb0c1f60c",
                 "shasum": ""
             },
             "require": {
@@ -152,9 +152,13 @@
                 "MIT"
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/1.8.x"
+                "source": "https://github.com/phpstan/phpstan/tree/1.9.x"
             },
             "funding": [
                 {
@@ -166,33 +170,29 @@
                     "type": "github"
                 },
                 {
-                    "url": "https://www.patreon.com/phpstan",
-                    "type": "patreon"
-                },
-                {
                     "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-07-17T06:08:12+00:00"
+            "time": "2022-11-03T21:45:22+00:00"
         },
         {
             "name": "rector/rector",
-            "version": "dev-main",
+            "version": "0.13.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "ce84017a2498e4817ccd010531ac6948d783f839"
+                "reference": "d1e069db8ad3b4aea2b968248370c21415e4c180"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/ce84017a2498e4817ccd010531ac6948d783f839",
-                "reference": "ce84017a2498e4817ccd010531ac6948d783f839",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/d1e069db8ad3b4aea2b968248370c21415e4c180",
+                "reference": "d1e069db8ad3b4aea2b968248370c21415e4c180",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2|^8.0",
-                "phpstan/phpstan": "^1.8"
+                "phpstan/phpstan": "^1.8.2"
             },
             "conflict": {
                 "phpstan/phpdoc-parser": "<1.6.2",
@@ -205,7 +205,6 @@
                 "rector/rector-prefixed": "*",
                 "rector/rector-symfony": "*"
             },
-            "default-branch": true,
             "bin": [
                 "bin/rector"
             ],
@@ -227,7 +226,7 @@
             "description": "Instant Upgrade and Automated Refactoring of any PHP code",
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/main"
+                "source": "https://github.com/rectorphp/rector/tree/0.13.10"
             },
             "funding": [
                 {
@@ -235,7 +234,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-07-17T12:27:00+00:00"
+            "time": "2022-08-03T12:48:10+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -243,12 +242,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "f3a83428055642b09d14ec216ceae7107817c117"
+                "reference": "cd5acaa651df870e8a3207926f236400361219e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/f3a83428055642b09d14ec216ceae7107817c117",
-                "reference": "f3a83428055642b09d14ec216ceae7107817c117",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/cd5acaa651df870e8a3207926f236400361219e0",
+                "reference": "cd5acaa651df870e8a3207926f236400361219e0",
                 "shasum": ""
             },
             "require": {
@@ -285,14 +284,15 @@
             "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
-                "standards"
+                "standards",
+                "static analysis"
             ],
             "support": {
                 "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2022-06-27T22:52:37+00:00"
+            "time": "2022-10-21T05:57:32+00:00"
         },
         {
             "name": "webonyx/graphql-php",
@@ -300,12 +300,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/webonyx/graphql-php.git",
-                "reference": "6070542725b61fc7d0654a8a9855303e5e157434"
+                "reference": "04a48693acd785330eefd3b0e4fa67df8dfee7c3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/6070542725b61fc7d0654a8a9855303e5e157434",
-                "reference": "6070542725b61fc7d0654a8a9855303e5e157434",
+                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/04a48693acd785330eefd3b0e4fa67df8dfee7c3",
+                "reference": "04a48693acd785330eefd3b0e4fa67df8dfee7c3",
                 "shasum": ""
             },
             "require": {
@@ -358,7 +358,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2022-04-13T16:25:32+00:00"
+            "time": "2022-09-21T15:35:03+00:00"
         }
     ],
     "packages-dev": [],

--- a/src/ruleset.xml
+++ b/src/ruleset.xml
@@ -19,5 +19,6 @@
 
     <rule ref="./../vendor/magento/magento-coding-standard/Magento2" >
         <exclude name="Magento2.Annotation.MethodAnnotationStructure" />
+        <exclude name="Magento2.Commenting.ClassPropertyPHPDocFormatting.Missing" />
     </rule>
 </ruleset>


### PR DESCRIPTION
1 Updated magento coding-standard version to actual
2 Removed `Magento2.Commenting.ClassPropertyPHPDocFormatting.Missing`. It is really annoying.